### PR TITLE
만료된 액세스토큰 재발급, 로그아웃 시 토큰 테이블에 데이터 삭제, 스프링 부트 단 쿠키 발송, 자동 로그인 및 로그인 정보 재발급 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,8 @@ import MyPage from "./pages/UserInterface/MyPage/MyPage";
 import Login from "./pages/UserInterface/Login/Login";
 import SignUp from "./pages/UserInterface/Login/SignUp";
 import InsertReviewPage from "./pages/UserInterface/Review/InsertReviewPage";
+import Test from "./pages/UserInterface/Login/test";
+import "./api/AxiosInterCeptor";
 
 function App() {
   const [count, setCount] = useState(0);
@@ -34,6 +36,7 @@ function App() {
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/login" element={<Login />} />
           <Route path="/sign-up" element={<SignUp />} />
+          <Route path="/test" element={<Test />}/>
         </Routes>
       </AuthProvider>
       <ChattingBtn />

--- a/src/api/AxiosInterCeptor.js
+++ b/src/api/AxiosInterCeptor.js
@@ -1,0 +1,62 @@
+import axios from "axios";
+import cookies from "js-cookie";
+
+const API_URL = window.ENV?.API_URL;
+axios.defaults.baseURL = API_URL;
+
+axios.interceptors.request.use(config => {
+  if (config.url?.includes("/api/auth/refresh")){
+    console.log("ASDFASDFASDFASF");
+    return config;
+  }
+  const accessToken = sessionStorage.getItem('accessToken');
+  if (accessToken){
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  console.log(accessToken);
+  return config;
+});
+
+axios.interceptors.response.use(
+  
+  response => response,
+  async error => {
+    const originalReq = error.config;
+    let refreshToken = null;
+    if (
+      error.response?.status === 401 &&
+      !originalReq._retry &&
+      !originalReq.url.includes("/api/auth/refresh")
+    ) {
+      originalReq._retry = true;
+      try {
+        if (cookies.get("Refresh-Token")){
+          refreshToken = cookies.get("Refresh-Token");
+        } else {
+          refreshToken = sessionStorage.getItem("refreshToken");
+        }
+        const wrap = await axios.post(
+          "/api/auth/refresh",
+          {},
+          {
+            headers: { Authorization: `Bearer ${refreshToken}` },
+          }
+        );
+        if (wrap.data.header.code[0] !== 'S' ){
+          const msg = header.message || "토큰 갱신 실패";
+          return Promise.reject(new Error(msg));
+        }
+        const newTokens = wrap.data.body.items.tokens;
+        sessionStorage.setItem("refreshToken", newTokens.refreshToken);
+        sessionStorage.setItem("accessToken", newTokens.accessToken);
+        originalReq.headers.Authorization = `Bearer ${newTokens.accessToken}`;
+        return axios(originalReq);
+      } catch (refreshError) {
+        return Promise.reject(refreshError);
+      }
+    } 
+    return Promise.reject(error);
+  }
+)
+
+export default axios;

--- a/src/common/Header/Header.jsx
+++ b/src/common/Header/Header.jsx
@@ -1,27 +1,27 @@
-import { useState, useEffect } from "react";
+import { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import logoImage from "/src/assets/rog.png";
-
+import { AuthContext } from "../../provider/AuthContext";
 const Header = () => {
   const navigate = useNavigate();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      setIsLoggedIn(true);
-    }
-  }, []);
-
+  const { auth, logout } = useContext(AuthContext);
   const handleLogoClick = () => {
     navigate("/");
   };
 
   const handleAuthClick = () => {
-    if (isLoggedIn) {
+    if (auth.isAuthenticated) {
       navigate("/mypage");
     } else {
       navigate("/login");
+    }
+  };
+  const handleLogoutClick = () => {
+    if (auth.isAuthenticated) {
+      logout();
+    } else {
+      navigate("/sign-up");
     }
   };
 
@@ -38,12 +38,22 @@ const Header = () => {
       <div>
         <div></div>
       </div>
-      <div>
-        <div
-          onClick={handleAuthClick}
-          className="mr-[30px] cursor-pointer text-white font-semibold hover:text-gray-200 transition-colors"
-        >
-          {isLoggedIn ? "마이 페이지" : "로그인"}
+      <div className="button-area flex items-center space-x-4">
+        <div>
+          <div
+            onClick={handleAuthClick}
+            className="mr-[30px] cursor-pointer text-white font-semibold hover:text-gray-200 transition-colors"
+          >
+            {auth.isAuthenticated ? "마이 페이지" : "로그인"}
+          </div>
+        </div>
+        <div>
+          <div
+            onClick={handleLogoutClick}
+            className="mr-[30px] cursor-pointer text-white font-semibold hover:text-gray-200 transition-colors"
+          >
+            {auth.isAuthenticated ? "로그아웃" : "회원가입"}
+          </div>
         </div>
       </div>
     </header>

--- a/src/common/Header/Header.jsx
+++ b/src/common/Header/Header.jsx
@@ -4,7 +4,6 @@ import logoImage from "/src/assets/rog.png";
 import { AuthContext } from "../../provider/AuthContext";
 const Header = () => {
   const navigate = useNavigate();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const { auth, logout } = useContext(AuthContext);
   const handleLogoClick = () => {
     navigate("/");

--- a/src/hooks/useApi.js
+++ b/src/hooks/useApi.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import axios from "../api/AxiosInterCeptor";
 
 /**
  * 공통 API 요청 훅
@@ -11,24 +11,19 @@ const useApi = (url, options = {}, immediate = true) => {
   const [header, setHeader] = useState(null);
   const [body, setBody] = useState(null);
   const [error, setError] = useState(null);
-  const API_URL = window.ENV?.API_URL;
   const fetch = (overrideOptions = {}) => {
     setLoading(true);
     setError(null);
 
     const config = {
-      url: API_URL + url,
+      url,
       method: options.method || "get",
-      headers: {
-        ...(options.auth && {
-          Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`,
-        }),
-        ...(options.headers || {}),
-      },
+      headers: options.headers || {},
       withCredentials: options.withCredentials || false,
       ...options,
       ...overrideOptions,
     };
+    console.log(config);
     const promise = axios(config)
       .then( res => {
           const { header: hd, body: bd } = res.data;
@@ -45,7 +40,7 @@ const useApi = (url, options = {}, immediate = true) => {
           err.response?.data?.header?.message ||
           err.response?.data?.message ||
           err.message;
-          setError(err);
+          setError(msg);
         })
     promise.finally(() => setLoading(false));
     return promise;

--- a/src/pages/UserInterface/Login/Login.jsx
+++ b/src/pages/UserInterface/Login/Login.jsx
@@ -9,11 +9,12 @@ const Login = () => {
   const [formData, setFormData] = useState({
     memberId: "",
     memberPw: "",
+    authLogin: "N",
   });
   const navigate = useNavigate();
   const { login } = useContext(AuthContext);
   const [longTimeAuth, setLongTimeAuth] = useState(false);
-  const {header:loginHeader, body:loginBody, error : loginError, loading : loginLoading, refetch: loginApi} = useApi('/api/auth/tokens', { method: 'post', data: { memberId : formData.memberId, memberPw: formData.memberPw}}, false);
+  const {header:loginHeader, body:loginBody, error : loginError, loading : loginLoading, refetch: loginApi} = useApi('/api/auth/tokens', { method: 'post' }, false);
   const handleChange = (e) => {
   const { name, value } = e.target;
   setFormData((prev) => ({
@@ -25,16 +26,21 @@ const Login = () => {
   };
   const handleLogin = (e) => {
     e.preventDefault();
-    const { memberId, memberPw } = formData;
-
+    const { memberId, memberPw, authLogin} = formData;
+    
     if (!idRegex.test(memberId)){
       return;
     }
     if (!pwRegex.test(memberPw)){
       return;
     }
-    console.log(formData.memberId, formData.memberPw);
-    loginApi().then(({ header, body }) => {
+    console.log(formData.memberId, formData.memberPw, longTimeAuth);
+    const authLoginValue = longTimeAuth ? "Y" : "N";
+    console.log(formData);
+    loginApi({
+      withCredentials: true,
+      data: { memberId : memberId, memberPw: memberPw, authLogin: authLoginValue}
+    }).then(({ header, body }) => {
       if (header.code[0] === "S") {
         if (body.items.loginInfo.isActive === 'N'){
           alert("비활성화된 계정이거나 정지된 계정입니다.");

--- a/src/pages/UserInterface/Login/Login.jsx
+++ b/src/pages/UserInterface/Login/Login.jsx
@@ -1,41 +1,54 @@
-import React, { useState } from "react";
+import { useState, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Header from "../../../common/Header/Header"; // 이 컴포넌트는 사용자 환경에 맞게 있어야 합니다.
+import useApi from "../../../hooks/useApi";
+import { idRegex, pwRegex } from "../../../components/Regex";
+import { AuthContext } from "../../../provider/AuthContext";
 
 const Login = () => {
-  const [id, setId] = useState("");
-  const [password, setPassword] = useState("");
+  const [formData, setFormData] = useState({
+    memberId: "",
+    memberPw: "",
+  });
   const navigate = useNavigate();
-
-  const handleLogin = async (e) => {
-    e.preventDefault();
-
-    try {
-      const response = await fetch("/api/auth/member", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ id, password }),
-      });
-
-      if (response.ok) {
-        alert("로그인 성공!");
-        navigate("/");
-      } else {
-        const errorData = await response.json();
-        alert(
-          `로그인 실패: ${
-            errorData.message || "아이디 또는 비밀번호를 확인하세요."
-          }`
-        );
-      }
-    } catch (error) {
-      console.error("로그인 요청 중 오류 발생:", error);
-      alert("로그인 중 문제가 발생했습니다. 나중에 다시 시도해주세요.");
-    }
+  const { login } = useContext(AuthContext);
+  const [longTimeAuth, setLongTimeAuth] = useState(false);
+  const {header:loginHeader, body:loginBody, error : loginError, loading : loginLoading, refetch: loginApi} = useApi('/api/auth/tokens', { method: 'post', data: { memberId : formData.memberId, memberPw: formData.memberPw}}, false);
+  const handleChange = (e) => {
+  const { name, value } = e.target;
+  setFormData((prev) => ({
+    ...prev,
+    [name]: value,
+  }))};
+  const handleAgreementChange = (e) => {
+    setLongTimeAuth(e.target.checked);
   };
+  const handleLogin = (e) => {
+    e.preventDefault();
+    const { memberId, memberPw } = formData;
 
+    if (!idRegex.test(memberId)){
+      return;
+    }
+    if (!pwRegex.test(memberPw)){
+      return;
+    }
+    console.log(formData.memberId, formData.memberPw);
+    loginApi().then(({ header, body }) => {
+      if (header.code[0] === "S") {
+        if (body.items.loginInfo.isActive === 'N'){
+          alert("비활성화된 계정이거나 정지된 계정입니다.");
+          return;
+        }
+        login(body.items.loginInfo, body.items.tokens, false, longTimeAuth);
+        navigate(-1);
+      } else {
+        alert(`로그인 실패: ErrorCode ${header.code}`);
+      }
+    }).catch((err) => {
+      alert(err);
+    })
+  }
   const handleSocialLogin = (provider) => {
     alert(
       `${provider} 로그인은 현재 데모 상태입니다. 실제 구현 시에는 해당 소셜 로그인 API를 사용해야 합니다.`
@@ -78,9 +91,10 @@ const Login = () => {
               </label>
               <input
                 type="text"
-                id="id"
-                value={id}
-                onChange={(e) => setId(e.target.value)}
+                id="memberId"
+                name="memberId"
+                value={formData.memberId}
+                onChange={handleChange}
                 className="w-full px-3 py-2 mt-1 bg-white border-2 border-black focus:outline-none rounded-md"
                 required
               />
@@ -95,9 +109,10 @@ const Login = () => {
               </label>
               <input
                 type="password"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
+                id="memberPw"
+                name="memberPw"
+                value={formData.memberPw}
+                onChange={handleChange}
                 className="w-full px-3 py-2 mt-1 bg-white border-2 border-black focus:outline-none rounded-md"
                 required
               />
@@ -112,6 +127,21 @@ const Login = () => {
           </form>
 
           {/* ----- 추가된 부분 시작 ----- */}
+          <div className="flex items-center pt-2">
+              <input
+                type="checkbox"
+                id="agreement"
+                checked={longTimeAuth}
+                onChange={handleAgreementChange}
+                className="h-4 w-4 text-red-600 border-gray-300 rounded focus:ring-red-500"
+              />
+              <label
+                htmlFor="agreement"
+                className="ml-2 block text-sm text-gray-900"
+              >
+                로그인 유지
+              </label>
+            </div>
           <div className="space-y-4 text-sm text-center">
             {/* 아이디/비밀번호 찾기 링크 */}
             <div>

--- a/src/pages/UserInterface/Login/test.jsx
+++ b/src/pages/UserInterface/Login/test.jsx
@@ -1,0 +1,21 @@
+import { useState, useContext } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import useApi from "../../../hooks/useApi";
+
+const test = () => {
+  const {header, body, error, isLoading, fetch } = useApi("/api/test", {method: 'post'});
+  if (isLoading){
+    return <p>로딩 중</p>
+  }
+  if (error) {
+    return <p>에러: {error.toString()}</p>;
+  }
+  return (
+    <div>
+      <h2>Response Header</h2>
+      <p>코드: {header?.code}</p>
+      <p>메시지: {header?.message}</p>
+    </div>
+  );
+};
+export default test;

--- a/src/provider/AuthContext.jsx
+++ b/src/provider/AuthContext.jsx
@@ -1,71 +1,99 @@
 import { useState, useEffect, createContext, Children } from "react";
 import { useNavigate } from "react-router-dom";
-
+import cookies from "js-cookie";
+import TokenRefresher from "./TokenRefresher";
+import axios from "../api/AxiosInterCeptor"
 export const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
   const [auth, setAuth] = useState({
-    loginInfo: {},
-    tokens: {},
-    isLoading: true,
+    loginInfo: null,
+    tokens: null,
     isAuthenticated: false,
-    googleLoginState: false,
+    socialLoginState: false,
+    longTimeAuth: false,
   });
-
   useEffect(() => {
-    const loginInfo = JSON.parse(localStorage.getItem("loginInfo"));
-    const tokens = JSON.parse(localStorage.getItem("tokens"));
-    if (loginInfo && tokens && auth.googleLoginState) {
+    const loginInfo = JSON.parse(sessionStorage.getItem("loginInfo"));
+    const tokens = sessionStorage.getItem("refreshToken");
+    const hasCookie = !!cookies.get("Refresh-Token");
+    if (hasCookie && !sessionStorage.getItem("refreshToken")){
+      return;
+    } else if (loginInfo && tokens && auth.longTimeAuth){
       setAuth({
         loginInfo,
         tokens,
-        isLoading: false,
         isAuthenticated: true,
-        googleLoginState: true,
+        socialLoginState: false,
+        longTimeAuth: true,
+      });
+    } else if (loginInfo && tokens && auth.socialLoginState) {
+      setAuth({
+        loginInfo,
+        tokens,
+        isAuthenticated: true,
+        socialLoginState: true,
+        longTimeAuth: true,
       });
     } else if (loginInfo && tokens) {
       setAuth({
         loginInfo,
         tokens,
-        isLoading: false,
         isAuthenticated: true,
-        googleLoginState: false,
+        socialLoginState: false,
+        longTimeAuth: false,
       });
     }
   }, []);
 
-  const login = (loginInfo, tokens, googleLogin = false) => {
+  const login = (loginInfo, tokens, socialLogin = false, longTimeAuth = false) => {
     setAuth({
       loginInfo,
       tokens,
       isAuthenticated: true,
-      googleLoginState: googleLogin, // auth.googleLoginState -> true 구글로그인인 상태 false -> 일반로그인 상태
-      // 구글로그인 -> edifprofile 시에는 비밀번호 입력대신 이메일 인증으로 대신함
+      socialLoginState: socialLogin, 
+      longTimeAuth: longTimeAuth
     });
-    localStorage.setItem("loginInfo", JSON.stringify(loginInfo));
-    localStorage.setItem("tokens", JSON.stringify(tokens));
-    localStorage.setItem("googleLoginState", JSON.stringify(googleLogin));
-    console.log(JSON.stringify(tokens));
-    console.log(JSON.stringify(loginInfo));
+    sessionStorage.setItem("loginInfo", JSON.stringify(loginInfo));
+    sessionStorage.setItem("refreshToken", tokens.refreshToken);
+    sessionStorage.setItem("accessToken", tokens.accessToken);
+    sessionStorage.setItem("socialLoginState", JSON.stringify(socialLogin));
+    if (longTimeAuth){
+      cookies.set("Refresh-Token", tokens.refreshToken, {expires:30})
+    }
   };
 
   const logout = () => {
+    axios.delete("/api/auth/logout", { headers: { Authorization: `Bearer ${sessionStorage.getItem("accessToken")}` }
+    }).then(( wrap ) => {
+      console.log(wrap);
+      const header = wrap.data.header;
+      if (header.code[0] === 'S'){
+        alert("로그아웃에 되었습니다.")
+      } else {
+        alert("로그아웃 실패")
+      }
+    }).catch(err =>{
+      alert(err);
+    })
     setAuth({
-      loginInfo: {},
-      tokens: {},
-      isLoading: true,
+      loginInfo: null,
+      tokens: null,
       isAuthenticated: false,
-      googleLoginState: false,
+      socialLoginState: false,
+      longTimeAuth: false,
     });
-    localStorage.removeItem("loginInfo");
-    localStorage.removeItem("tokens");
-    localStorage.removeItem("googleLoginState");
-    navigate("/");
+    sessionStorage.removeItem("loginInfo");
+    sessionStorage.removeItem("refreshToken");
+    sessionStorage.removeItem("accessToken");
+    sessionStorage.removeItem("socialLoginState");
+    cookies.remove('Refresh-Token');
   };
 
   return (
     <AuthContext.Provider value={{ auth, login, logout }}>
+      {!!cookies.get("Refresh-Token") && !sessionStorage.getItem("refreshToken") && <TokenRefresher />}
       {children}
     </AuthContext.Provider>
   );

--- a/src/provider/TokenRefresher.jsx
+++ b/src/provider/TokenRefresher.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useContext } from "react";
 import useApi from "../hooks/useApi";
 import AuthContext from "./AuthContext";
-import Cookies from "js-cookie";
 
 function TokenRefresher() {
-  const { login, logout, setAuth } = useContext(AuthContext);
-  const refreshToken = Cookies.get("Refresh-Token");
-  if (!refreshToken) return null;
+  const { login, logout, loggingOut } = useContext(AuthContext);
+  
   // useApi 셋업: 즉시 호출하지 않도록 immediate = false
   const {
     header: tokenHeader,
@@ -14,11 +12,14 @@ function TokenRefresher() {
     error,
     loading,
     refetch: refresh,
-  } = useApi("/api/auth/refresh", { method: "post", headers: { Authorization: `Bearer ${refreshToken}`} }, false);
+  } = useApi("/api/auth/refresh", { method: "post", headers: { Authorization: `Bearer ${sessionStorage.getItem("refreshToken")}`}, withCredentials: true }, false);
 
   // 1) 컴포넌트 마운트 시 자동으로 토큰 갱신 시도
   useEffect(() => {
-    refresh();
+    console.log(loggingOut);
+    if (!loggingOut){
+      refresh();
+    }
   }, [refresh]);
 
   // 2) refresh() 호출 후 결과 처리

--- a/src/provider/TokenRefresher.jsx
+++ b/src/provider/TokenRefresher.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useContext } from "react";
+import useApi from "../hooks/useApi";
+import AuthContext from "./AuthContext";
+import Cookies from "js-cookie";
+
+function TokenRefresher() {
+  const { login, logout, setAuth } = useContext(AuthContext);
+  const refreshToken = Cookies.get("Refresh-Token");
+  if (!refreshToken) return null;
+  // useApi 셋업: 즉시 호출하지 않도록 immediate = false
+  const {
+    header: tokenHeader,
+    body: tokenBody,
+    error,
+    loading,
+    refetch: refresh,
+  } = useApi("/api/auth/refresh", { method: "post", headers: { Authorization: `Bearer ${refreshToken}`} }, false);
+
+  // 1) 컴포넌트 마운트 시 자동으로 토큰 갱신 시도
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // 2) refresh() 호출 후 결과 처리
+  useEffect(() => {
+    console.log("토큰리프레셔");
+    if (loading){
+      return;
+    }
+    if (error) {
+      // 네트워크 에러나 예외 발생
+      console.error(error);
+      logout();                   // 안전하게 로그아웃 처리
+      return;
+    }
+    console.log(tokenBody);
+    if(tokenHeader === null){
+      return;
+    }
+    if(!loading){
+      if (tokenHeader && tokenHeader.code[0]===("S")) {
+        login(tokenBody.items.loginInfo, tokenBody.items.tokens, false, true);
+      } else {
+        logout();
+      }
+    }
+  }, [loading, tokenBody, tokenBody, error, logout]);
+
+  return null; // 이 컴포넌트는 화면 렌더링 UI가 없고, 사이드이펙트만 수행
+}
+
+export default TokenRefresher;


### PR DESCRIPTION
[2025.07.01 09:06] 만료된 액세스토큰 재발급, 로그아웃 시 토큰 테이블에 데이터 삭제, 스프링 부트 단 쿠키 발송, 자동 로그인 및 로그인 정보 재발급 구현

1. 로그인 유지 버튼을 추가하였습니다. 로그인 유지 버튼 누른 후 로그인을 할 시 스프링부트에서 만료일 30일짜리 리프레쉬 토큰 값을 가진 쿠키를 발급하여 클라이언트에서 저장하도록 만들었습니다.
2. 클라이언트에서 처음 사이트 접속 시 서버에 요청을 보내 토큰이 있을 경우 계정 정보를 가져와 로그인 상태를 유지할 수 있습니다.
3. AxiosInterCeptor를 생성하였습니다. 이제 요청 헤더에 토큰 정보를 받아 넣을 수 있고 토큰의 만료일이 지나거나 유효하지 않다면 재발급하는 요청을 보낼 수 있습니다.
4. 3번의 내용으로 useApi를 사용할 때 권한이 필요한 요청일 경우 auth 데이터를 추가할 필요가 없어졌습니다.
5. AuthContext의 수정이 들어갔습니다. TokenRefresher.jsx의 경우 테스트 용도로 남겨져있어 추후 삭제 예정입니다.
6. 액세스 토큰의 재발급은 auth컨트롤러의 /api/auth/refresh를 통해 재발급을 할 수 있습니다.
7. 액세스 토큰의 재발급의 구현으로 액세스 토큰의 만료 시간은 5분으로 변경하였습니다.
8. 리액트 header의 로그인, 로그아웃, 회원가입, 마이페이지 네이게이터가 추가되었습니다. AuthContext를 통해 로그인인지 로그아웃인지 검증하는 부분이 추가되었으니 참고하시길 바랍니다.
# 중요!!!
useApi를 사용할 때 뒤에 false로 사용할 경우 위에 명시적 선언만 한 후에 useApi.then.catch로 사용할 수 있습니다. 이 때 위에 선언한 데이터 이외에 새로운 데이터가 들어가야할 경우
useApit( 새로운 데이터 형태 ).then().catch()
위 방식처럼 할 수 있습니다. 개발 중 참고 바랍니다.